### PR TITLE
Add `boxed()` and `boxed_local()` for StreamExt and the new `FutureExt`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,8 @@ pub use futures_core::Stream;
 pub use futures_io::{AsyncBufRead, AsyncRead, AsyncSeek, AsyncWrite};
 
 #[doc(no_inline)]
+pub use crate::future::FutureExt;
+#[doc(no_inline)]
 pub use crate::io::{AsyncBufReadExt, AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 #[doc(no_inline)]
 pub use crate::stream::StreamExt;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -640,7 +640,7 @@ pub trait StreamExt: Stream {
     /// use futures_lite::*;
     ///
     /// # blocking::block_on(async {
-    /// fn select<F: stream::Stream + Send>(_a: F, _b: F) {}
+    /// fn select<F: Stream + Send>(_a: F, _b: F) {}
     ///
     /// let mut a = stream::once(1);
     /// let mut b = stream::empty();
@@ -663,12 +663,12 @@ pub trait StreamExt: Stream {
     /// use futures_lite::*;
     ///
     /// # blocking::block_on(async {
-    /// fn select<F: stream::Stream>(_a: F, _b: F) {}
+    /// fn select_no_send<F: Stream>(_a: F, _b: F) {}
     ///
     /// let mut a = stream::once(1);
     /// let mut b = stream::empty();
     ///
-    /// select(a.boxed_local(), b.boxed_local());
+    /// select_no_send(a.boxed_local(), b.boxed_local());
     ///
     /// # })
     fn boxed_local<'a>(self) -> LocalBoxStream<'a, Self::Item>

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -28,6 +28,7 @@ use std::task::{Context, Poll};
 
 #[doc(no_inline)]
 pub use futures_core::stream::Stream;
+use futures_core::stream::{BoxStream, LocalBoxStream};
 use pin_project_lite::pin_project;
 
 use crate::ready;
@@ -629,6 +630,52 @@ pub trait StreamExt: Stream {
             f,
             acc: Some(init),
         }
+    }
+
+    /// Wrap the stream in a Box, pinning it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use futures_lite::*;
+    ///
+    /// # blocking::block_on(async {
+    /// fn select<F: stream::Stream + Send>(_a: F, _b: F) {}
+    ///
+    /// let mut a = stream::once(1);
+    /// let mut b = stream::empty();
+    ///
+    /// select(a.boxed(), b.boxed());
+    ///
+    /// # })
+    fn boxed<'a>(self) -> BoxStream<'a, Self::Item>
+    where
+        Self: Sized + Send + 'a,
+    {
+        Box::pin(self)
+    }
+
+    /// Wrap the stream in a Box which can't be sent to threads, pinning it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use futures_lite::*;
+    ///
+    /// # blocking::block_on(async {
+    /// fn select<F: stream::Stream>(_a: F, _b: F) {}
+    ///
+    /// let mut a = stream::once(1);
+    /// let mut b = stream::empty();
+    ///
+    /// select(a.boxed_local(), b.boxed_local());
+    ///
+    /// # })
+    fn boxed_local<'a>(self) -> LocalBoxStream<'a, Self::Item>
+    where
+        Self: Sized + 'a,
+    {
+        Box::pin(self)
     }
 }
 


### PR DESCRIPTION
Even though these are easily replaced by the corresponding calls to `Box::pin()`, having a suffix notation for it (i.e. `a.boxed()`) was useful enough for it to be used in some portions of `prodash`.

As the implementation is trivial, I hope adding it is still in the vein of being _lite_ .