### PR TITLE
optional no_std support

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -53,5 +53,5 @@ jobs:
       - name: Check it compiles no_std
         uses: actions-rs/cargo@v1
         with:
-          command: test
+          command: build
           args: --no-default-features

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -49,3 +49,9 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+
+      - name: Check it compiles no_std
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,15 @@ keywords = ["asynchronous", "futures", "async"]
 categories = ["asynchronous", "concurrency"]
 readme = "README.md"
 
+[features]
+std = ["futures-io", "parking"]
+default = ["std"]
+
 [dependencies]
 fastrand = "1.3.3"
 futures-core = "0.3.5"
-futures-io = { version = "0.3.5", default-features = false, features = ["std"] }
+futures-io = { version = "0.3.5", optional = true }
 memchr = "2.3.3"
-parking = "1.0.5"
+parking = { version = "1.0.5", optional = true }
 pin-project-lite = "0.1.7"
 waker-fn = "1.0.0"

--- a/src/future.rs
+++ b/src/future.rs
@@ -18,20 +18,34 @@
 // TODO: race!, try_race(), try_race! (randomized for fairness)
 // TODO: join!, try_join!
 
-use std::cell::RefCell;
-use std::fmt;
+use core::fmt;
 #[doc(no_inline)]
-pub use std::future::Future;
-use std::marker::PhantomData;
-use std::pin::Pin;
-use std::task::{Context, Poll, Waker};
+pub use core::future::Future;
+use core::marker::PhantomData;
+use core::pin::Pin;
 
-use parking::Parker;
 use pin_project_lite::pin_project;
-use waker_fn::waker_fn;
 
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+#[cfg(not(feature = "std"))]
+use core::task::{Context, Poll};
+
+#[cfg(feature = "std")]
+use parking::Parker;
+#[cfg(feature = "std")]
+use waker_fn::waker_fn;
+#[cfg(feature = "std")]
+use core::task::{Context, Poll, Waker};
+#[cfg(feature = "std")]
+use core::cell::RefCell;
+
+#[cfg(feature = "std")]
 use crate::pin;
 
+#[cfg(feature = "std")]
 /// Blocks the current thread on a future.
 ///
 /// # Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,24 +22,33 @@
 
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
 #[doc(no_inline)]
-pub use std::future::Future;
+pub use core::future::Future;
 
 #[doc(no_inline)]
 pub use futures_core::Stream;
+
+#[cfg(feature = "std")]
 #[doc(no_inline)]
 pub use futures_io::{AsyncBufRead, AsyncRead, AsyncSeek, AsyncWrite};
 
 #[doc(no_inline)]
 pub use crate::future::FutureExt;
+
+#[cfg(feature = "std")]
 #[doc(no_inline)]
 pub use crate::io::{AsyncBufReadExt, AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
+
 #[doc(no_inline)]
 pub use crate::stream::StreamExt;
 
 pub mod future;
-pub mod io;
 pub mod stream;
+
+#[cfg(feature = "std")]
+pub mod io;
 
 /// Unwraps `Poll<T>` or returns [`Pending`][`std::task::Poll::Pending`].
 ///
@@ -65,8 +74,8 @@ pub mod stream;
 macro_rules! ready {
     ($e:expr $(,)?) => {
         match $e {
-            std::task::Poll::Ready(t) => t,
-            std::task::Poll::Pending => return std::task::Poll::Pending,
+            core::task::Poll::Ready(t) => t,
+            core::task::Poll::Pending => return core::task::Poll::Pending,
         }
     };
 }
@@ -97,7 +106,7 @@ macro_rules! pin {
             let mut $x = $x;
             #[allow(unused_mut)]
             let mut $x = unsafe {
-                std::pin::Pin::new_unchecked(&mut $x)
+                core::pin::Pin::new_unchecked(&mut $x)
             };
         )*
     }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -28,19 +28,25 @@
 // cmp(), partial_cmp(), ne(), ge(), eq(), gt(), le(), lt(),
 // sum(), product()
 
-use std::fmt;
-use std::future::Future;
-use std::marker::PhantomData;
-use std::mem;
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use core::fmt;
+use core::future::Future;
+use core::marker::PhantomData;
+use core::mem;
+use core::pin::Pin;
+use core::task::{Context, Poll};
 
 #[doc(no_inline)]
 pub use futures_core::stream::Stream;
 use pin_project_lite::pin_project;
 
+#[cfg(feature = "std")]
 use crate::future;
 use crate::ready;
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
 
 /// Converts a stream into a blocking iterator.
 ///
@@ -64,6 +70,7 @@ pub fn block_on<S: Stream + Unpin>(stream: S) -> BlockOn<S> {
 #[derive(Debug)]
 pub struct BlockOn<S>(S);
 
+#[cfg(feature = "std")]
 impl<S: Stream + Unpin> Iterator for BlockOn<S> {
     type Item = S::Item;
 
@@ -855,14 +862,14 @@ mod try_hack {
         type Ok;
         type Err;
 
-        fn into_result(self) -> std::result::Result<Self::Ok, Self::Err>;
+        fn into_result(self) -> core::result::Result<Self::Ok, Self::Err>;
     }
 
-    impl<T, E> Result for std::result::Result<T, E> {
+    impl<T, E> Result for core::result::Result<T, E> {
         type Ok = T;
         type Err = E;
 
-        fn into_result(self) -> std::result::Result<T, E> {
+        fn into_result(self) -> core::result::Result<T, E> {
             self
         }
     }


### PR DESCRIPTION
Some things need `alloc`, possible we could do some things without it, but not today.

Adds a new feature 'std', which is default-enabled. When disabled, we don't need `parking` or `futures-io`