### PR TITLE
Switch to unconditional no_std attribute

### DIFF
--- a/src/future.rs
+++ b/src/future.rs
@@ -29,7 +29,9 @@ use pin_project_lite::pin_project;
 #[cfg(feature = "std")]
 use std::{
     any::Any,
+    boxed::Box,
     panic::{catch_unwind, AssertUnwindSafe, UnwindSafe},
+    thread_local,
 };
 
 #[cfg(feature = "race")]

--- a/src/io.rs
+++ b/src/io.rs
@@ -21,14 +21,18 @@ pub use std::io::{Error, ErrorKind, Result, SeekFrom};
 pub use futures_io::{AsyncBufRead, AsyncRead, AsyncSeek, AsyncWrite};
 
 use std::borrow::{Borrow, BorrowMut};
+use std::boxed::Box;
 use std::cmp;
 use std::fmt;
 use std::future::Future;
 use std::io::{IoSlice, IoSliceMut};
 use std::mem;
 use std::pin::Pin;
+use std::string::String;
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
+use std::vec;
+use std::vec::Vec;
 
 use futures_core::stream::Stream;
 use pin_project_lite::pin_project;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,8 @@
 //! }
 //! ```
 
+#![no_std]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
-#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::needless_borrow)] // suggest code that doesn't work on MSRV
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/smol-rs/smol/master/assets/images/logo_fullsize_transparent.png"
@@ -35,6 +35,12 @@
     html_logo_url = "https://raw.githubusercontent.com/smol-rs/smol/master/assets/images/logo_fullsize_transparent.png"
 )]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;
 
 #[cfg(feature = "std")]
 #[doc(no_inline)]

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -15,13 +15,10 @@
 //! # });
 //! ```
 
-#[cfg(all(not(feature = "std"), feature = "alloc"))]
-extern crate alloc;
-
 #[doc(no_inline)]
 pub use futures_core::stream::Stream;
 
-#[cfg(all(not(feature = "std"), feature = "alloc"))]
+#[cfg(feature = "alloc")]
 use alloc::boxed::Box;
 
 use core::fmt;


### PR DESCRIPTION
Makes dependencies on std clearer by avoiding the prelude.

We could also convert some `std` imports to `alloc` imports now, and maybe some of the `std`-gated code can actually become `alloc`-gated.