### PR TITLE
Fix failing docs build

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/smol-rs/smol/master/assets/images/logo_fullsize_transparent.png"
 )]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
The `doc_auto_cfg` attribute has been renamed to `doc_cfg`
See https://github.com/rust-lang/rust/issues/43781

Fixes https://github.com/smol-rs/futures-lite/issues/140