### PR TITLE
Fix read_line panic on non-empty buffer

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -1918,7 +1918,7 @@ fn read_line_internal<R: AsyncBufRead + ?Sized>(
         *buf = s;
         Poll::Ready(ret)
     } else {
-        let Ok(s) = str::from_utf8(bytes) else {
+        let Ok(s) = core::str::from_utf8(bytes) else {
             bytes.clear();
             return Poll::Ready(ret.and_then(|_| Err(utf8_err())));
         };

--- a/src/io.rs
+++ b/src/io.rs
@@ -3113,7 +3113,7 @@ mod tests {
     fn non_empty_buffer() {
         spin_on::spin_on(async {
             let mut bytes = "foo".as_bytes();
-            let mut buf = String::from("bar");
+            let mut buf = std::string::String::from("bar");
             bytes.read_line(&mut buf).await.unwrap();
             assert_eq!(&buf, "barfoo");
         });

--- a/src/io.rs
+++ b/src/io.rs
@@ -1908,19 +1908,23 @@ fn read_line_internal<R: AsyncBufRead + ?Sized>(
 ) -> Poll<Result<usize>> {
     let ret = ready!(read_until_internal(reader, cx, b'\n', bytes, read));
 
-    match String::from_utf8(mem::take(bytes)) {
-        Ok(s) => {
-            debug_assert!(buf.is_empty());
-            debug_assert_eq!(*read, 0);
-            *buf = s;
-            Poll::Ready(ret)
-        }
-        Err(_) => Poll::Ready(ret.and_then(|_| {
-            Err(Error::new(
-                ErrorKind::InvalidData,
-                "stream did not contain valid UTF-8",
-            ))
-        })),
+    let utf8_err = || Error::new(ErrorKind::InvalidData, "stream did not contain valid UTF-8");
+
+    if buf.is_empty() {
+        let Ok(s) = String::from_utf8(mem::take(bytes)) else {
+            return Poll::Ready(ret.and_then(|_| Err(utf8_err())));
+        };
+        debug_assert_eq!(*read, 0);
+        *buf = s;
+        Poll::Ready(ret)
+    } else {
+        let Ok(s) = str::from_utf8(bytes) else {
+            bytes.clear();
+            return Poll::Ready(ret.and_then(|_| Err(utf8_err())));
+        };
+        debug_assert_eq!(*read, 0);
+        buf.push_str(s);
+        Poll::Ready(ret)
     }
 }
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -1924,6 +1924,7 @@ fn read_line_internal<R: AsyncBufRead + ?Sized>(
         };
         debug_assert_eq!(*read, 0);
         buf.push_str(s);
+        bytes.clear();
         Poll::Ready(ret)
     }
 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -3104,3 +3104,18 @@ use memchr::memchr;
 fn memchr(needle: u8, haystack: &[u8]) -> Option<usize> {
     haystack.iter().position(|&b| b == needle)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::AsyncBufReadExt;
+
+    #[test]
+    fn non_empty_buffer() {
+        spin_on::spin_on(async {
+            let mut bytes = "foo".as_bytes();
+            let mut buf = String::from("bar");
+            bytes.read_line(&mut buf).await.unwrap();
+            assert_eq!(&buf, "barfoo");
+        });
+    }
+}


### PR DESCRIPTION
This is building on https://github.com/smol-rs/futures-lite/pull/126, taking into account the review that was made on the original PR.

 This commit adds a check for the buffer being empty, and otherwise appends to the string, without an extra allocation as suggested in https://github.com/smol-rs/futures-lite/pull/126#discussion_r1962332546

If the read bytes are not utf-8, they are still discarded as pointed out in https://github.com/smol-rs/futures-lite/pull/126#discussion_r1962332546
